### PR TITLE
Update issue-to-md GitHub action to only be triggered when the owner of the repo wrote the issue

### DIFF
--- a/.github/workflows/issue-to-md.yml
+++ b/.github/workflows/issue-to-md.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   create-post:
     runs-on: ubuntu-latest
+    if: ${{ github.event.issue.user.login == github.repository_owner }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Update GitHub Action to only trigger when the issue author is the repository owner

* Add an `if` clause at the job level in `.github/workflows/issue-to-md.yml` to check if the issue author and the repository owner match.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/chekos/chekos.dev/pull/19?shareId=7d87db98-7a83-405c-817c-60b7ac2032d5).